### PR TITLE
Get rid of btmgmt dependency

### DIFF
--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -25,17 +25,23 @@ def get_current_time():
     )
 
 
+def get_default_adapter():
+    """ https://stackoverflow.com/a/49017827 """
+    import dbus
+    bus = dbus.SystemBus()
+    manager = dbus.Interface(bus.get_object('org.bluez', '/'), 'org.freedesktop.DBus.ObjectManager')
+    for path, ifaces in manager.GetManagedObjects().items():
+        if ifaces.get('org.bluez.Adapter1') is None:
+            continue
+        return path.split('/')[-1]
+    return None
+
+
 class InfiniTimeManager(gatt.DeviceManager):
     def __init__(self):
-        cmd = "btmgmt info"
-        btmgmt_proc = Gio.Subprocess.new(
-            cmd.split(),
-            Gio.SubprocessFlags.STDIN_PIPE | Gio.SubprocessFlags.STDOUT_PIPE,
-        )
-        _, stdout, stderr = btmgmt_proc.communicate_utf8()
         self.conf = config()
         self.device_set = set()
-        self.adapter_name = stdout.splitlines()[1].split(":")[0]
+        self.adapter_name = get_default_adapter()
         self.alias = None
         self.scan_result = False
         self.mac_address = None

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -42,6 +42,8 @@ class InfiniTimeManager(gatt.DeviceManager):
         self.conf = config()
         self.device_set = set()
         self.adapter_name = get_default_adapter()
+        if not self.adapter_name:
+            raise NoAdapterFound
         self.alias = None
         self.scan_result = False
         self.mac_address = None
@@ -103,3 +105,7 @@ class InfiniTimeDevice(gatt.Device):
         )
 
         char.write_value(get_current_time())
+
+
+class NoAdapterFound(Exception):
+    pass

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gtk, Gio, Gdk
 from .window import SigloWindow
-from .bluetooth import InfiniTimeManager
+from .bluetooth import InfiniTimeManager, NoAdapterFound
 from .config import config
 
 
@@ -24,19 +24,22 @@ class Application(Gtk.Application):
         if not win:
             win = SigloWindow(application=self)
         win.present()
-        self.manager = InfiniTimeManager()
         info_prefix = "[INFO ] Done Scanning"
         try:
+            self.manager = InfiniTimeManager()
             self.manager.scan_for_infinitime()
         except gatt.errors.NotReady:
             info_prefix = "[WARN ] Bluetooth is disabled"
+        except NoAdapterFound:
+            info_prefix = "[WARN ] No Bluetooth adapter found"
         if self.conf.get_property("mode") == "singleton":
             win.done_scanning_singleton(self.manager, info_prefix)
         if self.conf.get_property("mode") == "multi":
             win.done_scanning_multi(self.manager, info_prefix)
 
     def do_window_removed(self, window):
-        self.manager.stop()
+        if self.manager:
+            self.manager.stop()
         self.quit()
 
 

--- a/src/window.py
+++ b/src/window.py
@@ -87,11 +87,12 @@ class SigloWindow(Gtk.ApplicationWindow):
 
     def done_scanning_multi(self, manager, info_prefix):
         self.manager = manager
-        scan_result = manager.get_scan_result()
+        if manager:
+            scan_result = manager.get_scan_result()
         self.bt_spinner.set_visible(False)
         self.rescan_button.set_visible(True)
         info_suffix = "\n[INFO ] Multi-Device Mode"
-        if scan_result:
+        if manager and scan_result:
             info_suffix += "\n[INFO ] Scan Succeeded"
             self.populate_listbox()
         else:
@@ -101,10 +102,11 @@ class SigloWindow(Gtk.ApplicationWindow):
 
     def done_scanning_singleton(self, manager, info_prefix):
         self.manager = manager
-        scan_result = manager.get_scan_result()
+        if manager:
+            scan_result = manager.get_scan_result()
         self.bt_spinner.set_visible(False)
         info_suffix = "\n[INFO ] Single-Device Mode"
-        if scan_result:
+        if manager and scan_result:
             info_suffix += "\n[INFO ] Scan Succeeded"
             self.info_scan_pass.set_text(
                 manager.alias


### PR DESCRIPTION
Fixes #4

Use D-Bus instead of `btmgmt` to find default Bluetooth adapter.
Also gracefully handle case where no Bluetooth adapter is present.

Tested on:
- Fedora 33 x86_64
- PinePhone running postmarketOS v21.03