### PR TITLE
Fix flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,38 @@ echo "power on" | sudo bluetoothctl
 ```
 Icons by svgrepo.com
 
+## Building and installing Flatpak app
+
+### Building and installing on target architecture
+
+```
+flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak install --user flathub org.gnome.Sdk//3.38 org.gnome.Platform//3.38
+
+flatpak-builder --repo=repo --force-clean build-dir/ org.gnome.siglo.json
+flatpak build-bundle ./repo/ siglo.flatpak org.gnome.siglo
+flatpak install --user ./siglo.flatpak
+```
+
+### Cross-compiling for PinePhone
+
+Example cross-compiling for PinePhone on an `x86_64` Fedora machine:
+
+```
+sudo dnf install qemu-system-arm qemu-user-static
+flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak install --user flathub org.gnome.Sdk/aarch64/3.38 org.gnome.Platform/aarch64/3.38
+
+flatpak-builder --arch=aarch64 --repo=repo --force-clean build-dir org.gnome.siglo.json
+flatpak build-bundle --arch=aarch64 ./repo/ siglo.flatpak org.gnome.siglo
+```
+
+Transfer the `siglo.flatpak` file on the PinePhone and install it with the following command:
+
+```
+sudo flatpak install ./siglo.flatpak
+```
+
 ##
 If this project helped you, you can buy me a cup of coffee :)
 <br/><br/>

--- a/data/org.gnome.siglo.appdata.xml.in
+++ b/data/org.gnome.siglo.appdata.xml.in
@@ -4,5 +4,8 @@
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>LicenseRef-proprietary</project_license>
 	<description>
+	  <p>
+	    GTK app to sync InfiniTime watch with PinePhone
+	  </p>
 	</description>
 </component>

--- a/org.gnome.siglo.json
+++ b/org.gnome.siglo.json
@@ -5,9 +5,11 @@
     "sdk" : "org.gnome.Sdk",
     "command" : "siglo",
     "finish-args" : [
+        "--allow=bluetooth",
         "--share=network",
         "--share=ipc",
         "--socket=fallback-x11",
+        "--socket=system-bus",
         "--socket=wayland"
     ],
     "cleanup" : [
@@ -47,13 +49,38 @@
             ]
         },
         {
+            "name": "python3-requests",
+            "buildsystem": "simple",
+            "build-options": {
+                "build-args": [
+                    "--share=network"
+                ]
+            },
+            "build-commands": [
+                "pip3 install --prefix=/app --no-cache-dir requests"
+            ]
+        },
+        {
+            "name": "python3-pyxdg",
+            "buildsystem": "simple",
+            "build-options": {
+                "build-args": [
+                    "--share=network"
+                ]
+            },
+            "build-commands": [
+                "pip3 install --prefix=/app --no-cache-dir pyxdg"
+            ]
+        },
+        {
             "name" : "siglo",
             "builddir" : true,
             "buildsystem" : "meson",
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "file:///home/malex/Projects/siglo"
+                    "url" : "https://github.com/alexr4535/siglo",
+                    "tag" : "v0.6.2"
                 }
             ]
         }

--- a/src/config.py
+++ b/src/config.py
@@ -1,12 +1,12 @@
 import configparser
+import xdg.BaseDirectory
 from pathlib import Path
 
 
 class config:
     # Class constants
     default_config = {"mode": "singleton", "deploy_type": "quick"}
-    home_dir = str(Path.home())
-    config_dir = home_dir + "/.config/siglo"
+    config_dir = xdg.BaseDirectory.xdg_config_home
     config_file = config_dir + "/siglo.ini"
 
     def load_defaults(self):


### PR DESCRIPTION
Fix Flatpak manifest.
Document how to build and install Flatpak on same architecture, and cross-compile for PinePhone.

This assumes that a tag `v0.6.2` will be created after merging this PR such that the GitHub repo can be used as source.

Tested on:
- Fedora 33 x86_64
- PinePhone running postmarketOS v21.03