### PR TITLE
README.md - Add dependency for 0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ GTK app to sync InfiniTime watch with PinePhone
 ## Dependancies
 ### Arch Linux
 ```
-sudo pacman -S meson python-pip base-devel bluez bluez-utils dbus-python
-pip3 install gatt
+sudo pacman -S --needed meson python-pip base-devel bluez bluez-utils dbus-python
+pip3 install gatt pyxdg
 ```
 ### Ubuntu
 ```


### PR DESCRIPTION
On Arch, for 0.6.2 I needed to install pyxdg on both my Pinebook Pro (Manjaro ARM) and Pinephone (danctnix Arch). Was not the case with my Ubuntu 20.04 LTS laptop,  so haven't changed the Ubuntu dependencies. I also added the `--needed` flag as unlike `apt` on debian, `pacman` will (needlessly) reinstall any listed packages that are already installed without that flag. 

A direct result of the changes in https://github.com/alexr4535/siglo/pull/26 , fixing the Flatpak build. 

```
Traceback (most recent call last):
  File "/usr/local/bin/siglo", line 24, in <module>
    from siglo import main
  File "/usr/local/share/siglo/siglo/main.py", line 8, in <module>
    from .window import SigloWindow
  File "/usr/local/share/siglo/siglo/window.py", line 4, in <module>
    from .bluetooth import InfiniTimeDevice
  File "/usr/local/share/siglo/siglo/bluetooth.py", line 5, in <module>
    from .config import config
  File "/usr/local/share/siglo/siglo/config.py", line 2, in <module>
    import xdg.BaseDirectory
ModuleNotFoundError: No module named 'xdg.BaseDirectory'
```