### PR TITLE
Reliability and error reporting improvements

### DIFF
--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -81,12 +81,17 @@ class InfiniTimeManager(gatt.DeviceManager):
 
 
 class InfiniTimeDevice(gatt.Device):
+    def connect(self):
+        self.successful_connection = True
+        super().connect()
+
     def connect_succeeded(self):
         super().connect_succeeded()
         print("[%s] Connected" % (self.mac_address))
 
     def connect_failed(self, error):
         super().connect_failed(error)
+        self.successful_connection = False
         print("[%s] Connection failed: %s" % (self.mac_address, str(error)))
 
     def disconnect_succeeded(self):

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -29,12 +29,17 @@ def get_default_adapter():
     """ https://stackoverflow.com/a/49017827 """
     import dbus
     bus = dbus.SystemBus()
-    manager = dbus.Interface(bus.get_object('org.bluez', '/'), 'org.freedesktop.DBus.ObjectManager')
+    try:
+        manager = dbus.Interface(bus.get_object('org.bluez', '/'),
+                'org.freedesktop.DBus.ObjectManager')
+    except dbus.exceptions.DBusException:
+        raise BluetoothDisabled
+
     for path, ifaces in manager.GetManagedObjects().items():
         if ifaces.get('org.bluez.Adapter1') is None:
             continue
         return path.split('/')[-1]
-    return None
+    raise NoAdapterFound
 
 
 class InfiniTimeManager(gatt.DeviceManager):
@@ -42,8 +47,6 @@ class InfiniTimeManager(gatt.DeviceManager):
         self.conf = config()
         self.device_set = set()
         self.adapter_name = get_default_adapter()
-        if not self.adapter_name:
-            raise NoAdapterFound
         self.alias = None
         self.scan_result = False
         self.mac_address = None
@@ -106,6 +109,9 @@ class InfiniTimeDevice(gatt.Device):
 
         char.write_value(get_current_time())
 
+
+class BluetoothDisabled(Exception):
+    pass
 
 class NoAdapterFound(Exception):
     pass

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gtk, Gio, Gdk
 from .window import SigloWindow
-from .bluetooth import InfiniTimeManager, NoAdapterFound
+from .bluetooth import InfiniTimeManager, NoAdapterFound, BluetoothDisabled
 from .config import config
 
 
@@ -28,7 +28,7 @@ class Application(Gtk.Application):
         try:
             self.manager = InfiniTimeManager()
             self.manager.scan_for_infinitime()
-        except gatt.errors.NotReady:
+        except (gatt.errors.NotReady, BluetoothDisabled):
             info_prefix = "[WARN ] Bluetooth is disabled"
         except NoAdapterFound:
             info_prefix = "[WARN ] No Bluetooth adapter found"

--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,10 @@
 import sys
 import gi
-import gatt
 
 gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gtk, Gio, Gdk
 from .window import SigloWindow
-from .bluetooth import InfiniTimeManager, NoAdapterFound, BluetoothDisabled
 from .config import config
 
 
@@ -24,22 +22,12 @@ class Application(Gtk.Application):
         if not win:
             win = SigloWindow(application=self)
         win.present()
-        info_prefix = "[INFO ] Done Scanning"
-        try:
-            self.manager = InfiniTimeManager()
-            self.manager.scan_for_infinitime()
-        except (gatt.errors.NotReady, BluetoothDisabled):
-            info_prefix = "[WARN ] Bluetooth is disabled"
-        except NoAdapterFound:
-            info_prefix = "[WARN ] No Bluetooth adapter found"
-        if self.conf.get_property("mode") == "singleton":
-            win.done_scanning_singleton(self.manager, info_prefix)
-        if self.conf.get_property("mode") == "multi":
-            win.done_scanning_multi(self.manager, info_prefix)
+        win.do_scanning()
 
     def do_window_removed(self, window):
-        if self.manager:
-            self.manager.stop()
+        win = self.props.active_window
+        if win:
+            win.destroy_manager()
         self.quit()
 
 

--- a/src/window.py
+++ b/src/window.py
@@ -270,8 +270,10 @@ class SigloWindow(Gtk.ApplicationWindow):
             verbose=False,
         )
         self.ble_dfu.input_setup()
-        self.dfu_progress_text.set_text(self.get_prog_text())
+        self.update_progress_bar()
         self.ble_dfu.connect()
+        if not self.ble_dfu.successful_connection:
+            self.show_complete(success=False)
 
     @Gtk.Template.Callback()
     def deploy_type_toggled(self, widget):
@@ -306,13 +308,17 @@ class SigloWindow(Gtk.ApplicationWindow):
             str(self.ble_dfu.total_receipt_size)
             + " / "
             + str(self.ble_dfu.image_size)
-            + " bytes recieved"
+            + " bytes received"
         )
 
-    def show_complete(self):
-        self.main_info.set_text("OTA Update Complete")
+    def show_complete(self, success):
+        if success:
+            self.main_info.set_text("OTA Update Complete")
+        else:
+            self.main_info.set_text("OTA Update Failed")
         self.bt_spinner.set_visible(False)
         self.sync_time_button.set_visible(True)
         self.dfu_progress_box.set_visible(False)
+        self.ota_picked_box.set_visible(True)
         if (self.conf.get_property("deploy_type") == "quick"):
             self.auto_bbox_scan_pass.set_visible(True)

--- a/src/window.py
+++ b/src/window.py
@@ -182,7 +182,7 @@ class SigloWindow(Gtk.ApplicationWindow):
             self.manager.scan_result = False
             try:
                 self.manager.scan_for_infinitime()
-            except gatt.errors.NotReady:
+            except (gatt.errors.NotReady, gatt.errors.Failed):
                 info_prefix = "[WARN ] Bluetooth is disabled"
             if self.conf.get_property("mode") == "singleton":
                 self.done_scanning_singleton(self.manager, info_prefix)

--- a/src/window.py
+++ b/src/window.py
@@ -1,7 +1,7 @@
-import gatt
+import gatt.errors
 import urllib.request
 from gi.repository import Gtk, GObject
-from .bluetooth import InfiniTimeDevice
+from .bluetooth import InfiniTimeDevice, InfiniTimeManager, BluetoothDisabled, NoAdapterFound
 from .ble_dfu import InfiniTimeDFU
 from .unpacker import Unpacker
 from .quick_deploy import *
@@ -54,6 +54,41 @@ class SigloWindow(Gtk.ApplicationWindow):
         else:
             self.auto_switch_deploy_type = False
 
+    def destroy_manager(self):
+        if self.manager:
+            self.manager.stop()
+            self.manager = None
+
+    def do_scanning(self):
+        info_prefix = "[INFO ] Done Scanning"
+        if not self.manager:
+            # create manager if not present yet
+            try:
+                self.manager = InfiniTimeManager()
+            except (gatt.errors.NotReady, BluetoothDisabled):
+                info_prefix = "[WARN ] Bluetooth is disabled"
+            except NoAdapterFound:
+                info_prefix = "[WARN ] No Bluetooth adapter found"
+        if self.manager:
+            self.depopulate_listbox()
+            self.main_info.set_text("Rescanning...")
+            self.bt_spinner.set_visible(True)
+            self.bbox_scan_pass.set_visible(False)
+            self.auto_bbox_scan_pass.set_visible(False)
+            self.scan_fail_box.set_visible(False)
+            self.rescan_button.set_visible(False)
+            self.scan_pass_box.set_visible(False)
+            self.manager.scan_result = False
+            try:
+                self.manager.scan_for_infinitime()
+            except (gatt.errors.NotReady, gatt.errors.Failed):
+                info_prefix = "[WARN ] Bluetooth is disabled"
+                self.destroy_manager()
+        if self.conf.get_property("mode") == "singleton":
+            self.done_scanning_singleton(info_prefix)
+        if self.conf.get_property("mode") == "multi":
+            self.done_scanning_multi(info_prefix)
+
     def depopulate_listbox(self):
         children = self.multi_device_listbox.get_children()
         for child in children:
@@ -85,14 +120,13 @@ class SigloWindow(Gtk.ApplicationWindow):
         for asset in get_assets_by_tag(self.tag, self.full_list):
             self.ota_pick_asset_combobox.append_text(asset)
 
-    def done_scanning_multi(self, manager, info_prefix):
-        self.manager = manager
-        if manager:
-            scan_result = manager.get_scan_result()
+    def done_scanning_multi(self, info_prefix):
+        if self.manager:
+            scan_result = self.manager.get_scan_result()
         self.bt_spinner.set_visible(False)
         self.rescan_button.set_visible(True)
         info_suffix = "\n[INFO ] Multi-Device Mode"
-        if manager and scan_result:
+        if self.manager and scan_result:
             info_suffix += "\n[INFO ] Scan Succeeded"
             self.populate_listbox()
         else:
@@ -100,20 +134,19 @@ class SigloWindow(Gtk.ApplicationWindow):
             self.scan_fail_box.set_visible(True)
         self.main_info.set_text(info_prefix + info_suffix)
 
-    def done_scanning_singleton(self, manager, info_prefix):
-        self.manager = manager
-        if manager:
-            scan_result = manager.get_scan_result()
+    def done_scanning_singleton(self, info_prefix):
+        if self.manager:
+            scan_result = self.manager.get_scan_result()
         self.bt_spinner.set_visible(False)
         info_suffix = "\n[INFO ] Single-Device Mode"
-        if manager and scan_result:
+        if self.manager and scan_result:
             info_suffix += "\n[INFO ] Scan Succeeded"
             self.info_scan_pass.set_text(
-                manager.alias
+                self.manager.alias
                 + " Found!\n\nAdapter Name: "
-                + manager.adapter_name
+                + self.manager.adapter_name
                 + "\nMac Address: "
-                + manager.get_mac_address()
+                + self.manager.get_mac_address()
             )
             self.scan_pass_box.set_visible(True)
             self.ota_picked_box.set_visible(True)
@@ -168,26 +201,8 @@ class SigloWindow(Gtk.ApplicationWindow):
 
     @Gtk.Template.Callback()
     def rescan_button_clicked(self, widget):
-        if self.manager is not None:
-            print("[INFO ] Rescan button clicked")
-            self.depopulate_listbox()
-            self.main_info.set_text("Rescanning...")
-            self.bt_spinner.set_visible(True)
-            self.bbox_scan_pass.set_visible(False)
-            self.auto_bbox_scan_pass.set_visible(False)
-            self.scan_fail_box.set_visible(False)
-            self.rescan_button.set_visible(False)
-            self.scan_pass_box.set_visible(False)
-            info_prefix = "[INFO ] Done Scanning"
-            self.manager.scan_result = False
-            try:
-                self.manager.scan_for_infinitime()
-            except (gatt.errors.NotReady, gatt.errors.Failed):
-                info_prefix = "[WARN ] Bluetooth is disabled"
-            if self.conf.get_property("mode") == "singleton":
-                self.done_scanning_singleton(self.manager, info_prefix)
-            if self.conf.get_property("mode") == "multi":
-                self.done_scanning_multi(self.manager, info_prefix)
+        print("[INFO ] Rescan button clicked")
+        self.do_scanning()
 
     @Gtk.Template.Callback()
     def sync_time_button_clicked(self, widget):
@@ -199,6 +214,7 @@ class SigloWindow(Gtk.ApplicationWindow):
             device.connect()
             self.main_info.set_text("InfiniTime Sync... Success!")
             self.scan_pass_box.set_visible(False)
+            self.rescan_button.set_visible(True)
 
     @Gtk.Template.Callback()
     def ota_file_selected(self, widget):

--- a/src/window.py
+++ b/src/window.py
@@ -212,7 +212,10 @@ class SigloWindow(Gtk.ApplicationWindow):
                 manager=self.manager, mac_address=self.manager.get_mac_address()
             )
             device.connect()
-            self.main_info.set_text("InfiniTime Sync... Success!")
+            if device.successful_connection:
+                self.main_info.set_text("InfiniTime Sync... Success!")
+            else:
+                self.main_info.set_text("InfiniTime Sync... Failed!")
             self.scan_pass_box.set_visible(False)
             self.rescan_button.set_visible(True)
 


### PR DESCRIPTION
Fixes #28 

Various reliability and error reporting improvements:
- Correctly detect if Bluetooth service is not started: bug introduced in my PR #25
- Handle case where Bluetooth service gets stopped between scan and time sync.
- Handle Bluetooth service and adapter disconnection/reconnection without needing to restart app.
- Allow Rescan after time sync.
- Display error if Bluetooth gets disconnected, or an invalid response is received during OTA DFU.
- Improve OTA DFU reliability: wait for last segment acknowledgement before sending ValidateFirmware.

It would probably improve readability if the different commits in this PR were kept separate and not squashed together. I don't know if GitHub PR merging interface allows that.

Tested on:
- Fedora 33 x86_64
- PinePhone running postmarketOS v21.03
