### PR TITLE
Improve clarity of info_scan_fail error message

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -378,7 +378,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="vexpand">True</property>
-                <property name="label" translatable="yes">Make sure InfiniTime is ON but NOT connected
+                <property name="label" translatable="yes">Make sure your smartwatch running InfiniTime is turned ON and that it is NOT connected to bluetooth
 
 To check, go to Settings-&gt;Bluetooth-&gt;Devices
 


### PR DESCRIPTION
I found the original message not specific and obvious enough, when I encountered it I wasn't sure what the software wanted me to do. This commit should address this issue.