### PR TITLE
remove singleton mode

### DIFF
--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -90,15 +90,11 @@ class InfiniTimeManager(gatt.DeviceManager):
         if device.alias() in ("InfiniTime", "Pinetime-JF", "PineTime"):
             self.scan_result = True
             self.alias = device.alias()
-            if self.conf.get_property("mode") == "singleton":
-                self.mac_address = device.mac_address
-                self.stop()
-            if self.conf.get_property("mode") == "multi":
-                self.device_set.add(device.mac_address)
+            self.device_set.add(device.mac_address)
 
     def scan_for_infinitime(self):
         self.start_discovery()
-        self.set_timeout(4 * 1000)
+        self.set_timeout(1 * 1000)
         self.run()
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,6 @@ from pathlib import Path
 class config:
     # Class constants
     default_config = {
-        "mode": "singleton",
         "deploy_type": "quick",
         "last_paired_device": "None",
         "paired": "False",

--- a/src/window.ui
+++ b/src/window.ui
@@ -6,15 +6,6 @@
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <child>
-      <object class="GtkCheckMenuItem" id="multi_device_switch">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="label" translatable="yes">Multi-Device Mode</property>
-        <property name="use-underline">True</property>
-        <signal name="toggled" handler="mode_toggled" swapped="no"/>
-      </object>
-    </child>
-    <child>
       <object class="GtkCheckMenuItem" id="deploy_type_switch">
         <property name="visible">True</property>
         <property name="can-focus">False</property>


### PR DESCRIPTION
i did the opposite of the commit message, woops. to be clear, siglo no longer has a *single* device mode and the scan timeout is shortened. This simplifies the code and allows me to focus on making multi device mode better which is a popular feature.