### PR TITLE
Fix retry button

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -357,7 +357,7 @@ class SigloWindow(Gtk.ApplicationWindow):
     @Gtk.Template.Callback()
     def on_dfu_retry_clicked(self, widget):
         if self.firmware_mode == "auto":
-            self.on_firmware_run_clicked(self, widget)
+            self.on_firmware_run_clicked(widget)
 
     @Gtk.Template.Callback()
     def flash_it_button_clicked(self, widget):


### PR DESCRIPTION
When called as an instance method, self is already passed, so this was calling `on_firmware_run_clicked(self, self, widget)`, causing an error and making the retry not work