### PR TITLE
Add complete dependency list on Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:21.04
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ=" America/Los_Angeles"
+
+# xvfb is used to mock out the display for testing and is not required for real builds
+RUN apt update && apt install -y \
+    libgtk-3-dev python3-pip meson python3-dbus gtk-update-icon-cache desktop-file-utils gettext appstream-util libglib2.0-dev && \
+    apt install -y xvfb && \
+    rm -rf /var/lib/apt/lists/* && apt clean
+
+RUN pip3 install gatt pyxdg requests black
+
+COPY . /siglo
+
+WORKDIR /siglo
+
+RUN pwd && ls && mkdir -p ./build && \
+    meson --reconfigure ./build/ && \
+    cd ./build && ninja install
+
+CMD ["/bin/bash"]
+
+# Once the container is running, you should have all the dependencies you need
+# Start system dbus, then kickoff the app. For more details, you can see GTK's setup:
+# https://gitlab.gnome.org/GNOME/gtk/-/blob/fb052c8d2546706b49e5adb87bc88ad600f31752/.gitlab-ci.yml#L122
+#
+# /etc/init.d/dbus start && dbus-run-session xvfb-run -a -s "-screen 0 1024x768x24" siglo

--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
 # siglo
+
 GTK app to sync InfiniTime watch with PinePhone
 
 'siglo' means century in Spanish
 
 ## Dependencies
+
 ### Arch Linux
-```
+
+```sh
 sudo pacman -S --needed meson python-pip base-devel bluez bluez-utils dbus-python
 pip3 install gatt pyxdg
 ```
+
 ### Ubuntu
-```
-sudo apt install meson python3-dbus gettext appstream-util libglib2.0-dev
-pip3 install gatt
+
+```sh
+sudo apt install libgtk-3-dev python3-pip meson python3-dbus gtk-update-icon-cache desktop-file-utils gettext appstream-util libglib2.0-dev
+pip3 install gatt pyxdg requests black
 ```
 
 ## Build/Install
+
 ```
 git clone https://github.com/alexr4535/siglo.git
 cd siglo
@@ -25,11 +31,30 @@ cd build
 sudo ninja install
 ```
 
+### Mocked Testing with Docker
+
+While you won't get bluetooth connectivity, you can get some high-level vetting in a container, which
+will open the way forward to better CI testing on GitHub.
+
+The [`Dockerfile`](Dockerfile) contains all required dependencies, in addition to
+[`xvfb`](https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml) which allows us to make sure
+the app can execute.
+
+```sh
+sudo docker build . --tag siglo; and sudo docker run --name siglo --volume (pwd):/siglo --rm -it siglo:latest
+```
+
+Once the container is running, you can launch the app:
+
+```sh
+/etc/init.d/dbus start && dbus-run-session xvfb-run -a -s "-screen 0 1024x768x24" siglo
+```
+
 ## Building and installing Flatpak app
 
 ### Building and installing on target architecture
 
-```
+```sh
 flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 flatpak install --user flathub org.gnome.Sdk//3.38 org.gnome.Platform//3.38
 
@@ -42,7 +67,7 @@ flatpak install --user ./siglo.flatpak
 
 Example cross-compiling for PinePhone on an `x86_64` Fedora machine:
 
-```
+```sh
 sudo dnf install qemu-system-arm qemu-user-static
 flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 flatpak install --user flathub org.gnome.Sdk/aarch64/3.38 org.gnome.Platform/aarch64/3.38
@@ -53,11 +78,12 @@ flatpak build-bundle --arch=aarch64 ./repo/ siglo.flatpak org.gnome.siglo
 
 Transfer the `siglo.flatpak` file on the PinePhone and install it with the following command:
 
-```
+```sh
 sudo flatpak install ./siglo.flatpak
 ```
 
 ##
+
 If this project helped you, you can buy me a cup of coffee :)
 <br/><br/>
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/ironrobin)

--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -213,9 +213,5 @@ class BluetoothDisabled(Exception):
     pass
 
 
-class BluetoothDisabled(Exception):
-    pass
-
-
 class NoAdapterFound(Exception):
     pass


### PR DESCRIPTION
In order to figure this out (and make sure I was correct) I used a Docker container. By design it's awkward to support dbus & bluetooth from within a container, so totally understandable if you'd prefer to not include the Dockerfile in the repo.

I managed to get the app to run and print out "Bluetooth is disabled" which exercises a decent bit of the code. If this is helpful, it could be the start of some light CI/GitHub workflows to run some testing for PRs.

Thanks for the awesome app! 🎉 