### PR TITLE
Getting persistant pairing working

### DIFF
--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -75,8 +75,6 @@ class InfiniTimeManager(gatt.DeviceManager):
         return self.scan_result
 
     def get_device_set(self):
-        if self.conf.get_property("paired"):
-            self.device_set.add(self.conf.get_property("last_paired_device"))
         return self.device_set
 
     def get_adapter_name(self):
@@ -110,6 +108,8 @@ class InfiniTimeManager(gatt.DeviceManager):
 class InfiniTimeDevice(gatt.Device):
     def __init__(self, mac_address, manager):
         self.conf = config()
+        self.mac = mac_address
+        self.manager = manager
         super().__init__(mac_address, manager)
 
     def connect(self):
@@ -119,6 +119,7 @@ class InfiniTimeDevice(gatt.Device):
     def connect_succeeded(self):
         super().connect_succeeded()
         print("[%s] Connected" % (self.mac_address))
+        self.conf.set_property("last_paired_device", self.mac)
 
     def connect_failed(self, error):
         super().connect_failed(error)

--- a/src/window.py
+++ b/src/window.py
@@ -59,6 +59,7 @@ class SigloWindow(Gtk.ApplicationWindow):
     firmware_run = Gtk.Template.Child()
     firmware_file = Gtk.Template.Child()
     firmware_run_file = Gtk.Template.Child()
+    keep_paired_switch = Gtk.Template.Child()
 
     # Flasher
     dfu_stack = Gtk.Template.Child()
@@ -84,7 +85,6 @@ class SigloWindow(Gtk.ApplicationWindow):
             self.auto_switch_deploy_type = False
         if self.conf.get_property("paired"):
             self.auto_switch_paired = True
-            self.pair_switch.set_active(True)
         else:
             self.auto_switch_paired = False
         GObject.signal_new(
@@ -95,13 +95,18 @@ class SigloWindow(Gtk.ApplicationWindow):
             (GObject.TYPE_PYOBJECT,),
         )
 
-    def destroy_manager(self):
-        if self.manager:
-            self.manager.stop()
-            self.manager = None
+    def disconnect_paired_device(self):
+        try:
+            devices = self.manager.devices()
+            for d in devices:
+                if d.mac_address == self.manager.get_mac_address() and d.is_connected():
+                    d.disconnect()
+        finally:
+            self.conf.set_property("paired", "False")
 
     def destroy_manager(self):
         if self.manager:
+            self.disconnect_paired_device()
             self.manager.stop()
             self.manager = None
 
@@ -133,10 +138,6 @@ class SigloWindow(Gtk.ApplicationWindow):
         value_mac = Gtk.Label(label=mac, xalign=0.0)
         grid.attach(value_mac, 2, 1, 1, 1)
 
-        chkbox_pair = Gtk.CheckButton(label="Keep Paired")
-        chkbox_pair.set_margin_right(10)
-        grid.attach(chkbox_pair, 3, 0, 1, 2)
-
         arrow = Gtk.Image.new_from_icon_name("go-next-symbolic", Gtk.IconSize.BUTTON)
         grid.attach(arrow, 4, 0, 1, 2)
 
@@ -159,6 +160,9 @@ class SigloWindow(Gtk.ApplicationWindow):
                 self.main_stack.set_visible_child_name("nodevice")
         if not self.manager:
             return
+
+        if self.conf.get_property("paired"):
+            self.disconnect_paired_device()
 
         self.depopulate_listbox()
         self.manager.scan_result = False
@@ -242,9 +246,18 @@ class SigloWindow(Gtk.ApplicationWindow):
         mac = row.mac
         self.current_mac = mac
         alias = row.alias
-        thread = ConnectionThread(self.manager, mac, self.callback_device_connect)
-        thread.daemon = True
-        thread.start()
+
+        if self.conf.get_property("paired"):
+            self.disconnect_paired_device()
+
+        if self.keep_paired_switch.get_active():
+            self.conf.set_property("paired", "True")
+
+        if self.manager is not None:
+            thread = ConnectionThread(self.manager, mac, self.callback_device_connect)
+            thread.daemon = True
+            thread.start()
+
         self.watch_name.set_text(alias)
         self.watch_address.set_text(mac)
         self.main_stack.set_visible_child_name("watch")

--- a/src/window.ui
+++ b/src/window.ui
@@ -217,20 +217,72 @@
                 <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="margin-bottom">4</property>
-                    <property name="label" translatable="yes">Watches</property>
-                    <style>
-                      <class name="heading"/>
-                    </style>
+                    <property name="spacing">10</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin-bottom">4</property>
+                        <property name="label" translatable="yes">Watches</property>
+                        <style>
+                          <class name="heading"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Keep paired</property>
+                            <style>
+                              <class name="heading"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="keep_paired_switch">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack-type">end</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">0</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
@@ -263,7 +315,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>

--- a/src/window.ui
+++ b/src/window.ui
@@ -220,6 +220,7 @@
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="margin-bottom">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkLabel">


### PR DESCRIPTION
Changes:
 - Use a single switch for "keep paired" instead of a check box per device(we only ever connect one device at a time, right?)
 - Read and write the "paired" value of the config file and set the mac address of the last successfully connected device
 - Disconnect the paired device when Siglo is closed.(This might not be what a user would expect but its probably good enough until all off this is demonized)
 - In case Siglo exits unexpectedly, the watch remains connected at a lower level. At the moment I simply find, disconnect and then reconnect the watch when Siglo is started again.

 Todo:
 - When a device is disconnected it blocks for a noticeable amount of time, might want to implement asynchronous disconnects.