### PR TITLE
Adding custom form_factor values

### DIFF
--- a/data/com.github.alexr4535.siglo.appdata.xml.in
+++ b/data/com.github.alexr4535.siglo.appdata.xml.in
@@ -20,4 +20,9 @@
   	  <release version="0.8.12" date="2021-08-06"/>
   	</releases>
     <content_rating type="oars-1.1" />
+    <custom>
+      <value key="Purism::form_factor">workstation</value>
+      <value key="Purism::form_factor">mobile</value>
+    </custom>
+
 </component>


### PR DESCRIPTION
This should make Siglo show up in the PureOS Store on the Librem 5. 

For more info on this see https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps/