### PR TITLE
Fix crash without network access

### DIFF
--- a/src/quick_deploy.py
+++ b/src/quick_deploy.py
@@ -23,7 +23,10 @@ version_blacklist = (
 
 
 def get_quick_deploy_list():
-    r = requests.get(url)
+    try:
+        r = requests.get(url)
+    except requests.exceptions.ConnectionError:
+        return []
     d = json.loads(r.content)
     quick_deploy_list = []
     for item in d:


### PR DESCRIPTION
This allows Siglo to start when internet access is not available, either
because the user is outside service or the flatpak permission has been
disabled.