### PR TITLE
Fake daemon behavior

### DIFF
--- a/com.github.alexr4535.siglo.json
+++ b/com.github.alexr4535.siglo.json
@@ -10,7 +10,8 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--system-talk-name=org.bluez",
-        "--socket=wayland"
+        "--talk-name=org.freedesktop.portal.Desktop",
+        "--socket=wayland",
     ],
     "cleanup" : [
         "/include",

--- a/com.github.alexr4535.siglo.json
+++ b/com.github.alexr4535.siglo.json
@@ -11,7 +11,7 @@
         "--socket=fallback-x11",
         "--system-talk-name=org.bluez",
         "--talk-name=org.freedesktop.portal.Desktop",
-        "--socket=wayland",
+        "--socket=wayland"
     ],
     "cleanup" : [
         "/include",

--- a/src/siglo.in
+++ b/src/siglo.in
@@ -6,6 +6,12 @@ import sys
 import signal
 import gettext
 import argparse
+import dbus
+
+from dbus.mainloop.glib import DBusGMainLoop
+
+import gi
+from gi.repository import Gio,GLib
 
 VERSION = '@VERSION@'
 pkgdatadir = '@pkgdatadir@'
@@ -17,26 +23,27 @@ gettext.install('siglo', localedir)
 
 def main():
     p = argparse.ArgumentParser(description="app to sync InfiniTime watch")
-    p.add_argument('--start', '-d', required=False, action='store_true', help="start daemon")
-    p.add_argument('--stop', '-x', required=False, action='store_true', help="stop daemon")
+    p.add_argument('--hidden', required=False, action='store_true', help="Hide window at startup")
     args = p.parse_args()
-    from siglo import daemon
-    d = daemon.daemon()
 
-    if args.start:
-        d.start()
-    elif args.stop:
-        d.stop()
-    else:
-        import gi
+    resource = Gio.Resource.load(os.path.join(pkgdatadir, 'siglo.gresource'))
+    resource._register()
 
-        from gi.repository import Gio
-        resource = Gio.Resource.load(os.path.join(pkgdatadir, 'siglo.gresource'))
-        resource._register()
+    #check if a Siglo instance is already running
+    DBusGMainLoop(set_as_default=True)
+    bus = dbus.SessionBus()
+    try:
+        win_obj = bus.get_object('com.github.alexr4535.siglo','/com/github/alexr4535/siglo/window/1')
+        action_iface = dbus.Interface(win_obj, dbus_interface="org.gtk.Actions")
+        action_iface.Activate("show",[],{})
+        sys.exit(0)
+    except Exception as e:
+        pass
 
-        from siglo import main
-        sys.exit(main.main(VERSION))
+    from siglo import main
+    sys.exit(main.main(VERSION, args.hidden))
 
 if __name__ == '__main__':
     main()
+
 

--- a/src/window.py
+++ b/src/window.py
@@ -4,7 +4,7 @@ import threading
 import urllib.request
 from pathlib import Path
 import gatt
-from gi.repository import Gtk, GObject, GLib
+from gi.repository import Gtk, GObject, GLib, Gio
 from .bluetooth import (
     InfiniTimeDevice,
     InfiniTimeManager,
@@ -85,6 +85,13 @@ class SigloWindow(Gtk.ApplicationWindow):
             GObject.TYPE_PYOBJECT,
             (GObject.TYPE_PYOBJECT,),
         )
+
+        show_action = Gio.SimpleAction.new("show", None)
+        show_action.connect("activate", self.show_win)
+        self.add_action(show_action)
+
+    def show_win(self, p1, p2):
+        self.show()
 
     def disconnect_paired_device(self):
         try:
@@ -199,14 +206,17 @@ class SigloWindow(Gtk.ApplicationWindow):
         self.watch_battery.set_text(battery)
 
     @Gtk.Template.Callback()
+    def on_delete_siglo_win(self, win, event):
+        win.hide()
+        return True
+
+    @Gtk.Template.Callback()
     def on_watches_listbox_row_activated(self, widget, row):
         mac = row.mac
         self.current_mac = mac
         alias = row.alias
 
         if self.keep_paired_switch.get_active():
-            # Start daemon
-            subprocess.Popen(["systemctl", "--user", "start", "siglo"])
             self.conf.set_property("paired", "True")
 
         if self.manager is not None:

--- a/src/window.ui
+++ b/src/window.ui
@@ -25,6 +25,7 @@
     <property name="can-focus">False</property>
     <property name="default-width">600</property>
     <property name="default-height">300</property>
+    <signal name="delete-event" handler="on_delete_siglo_win" swapped="no"/>
     <signal name="set-focus" handler="on_window_focus" swapped="no"/>
     <child>
       <object class="GtkStack" id="main_stack">


### PR DESCRIPTION
A comment https://github.com/alexr4535/siglo/issues/80#issuecomment-912705825 about the current daemon issues presented an alternative implementation that piqued my interest. Here is my take on it.
I'm hiding the window when the close button is pressed, and un-hide it when a second instance of siglo is started, which is then killed.
I request background and autostart permissions using the Background portal and I also added a '--hidden' argument that is used by the autostart file.

This should be considered as a suggestion in case that we don't find a way to make the current implementation work in a Flatpak sandbox.