### PR TITLE
Allow a name suffix in the bluetooth alias

### DIFF
--- a/src/bluetooth.py
+++ b/src/bluetooth.py
@@ -94,10 +94,11 @@ class InfiniTimeManager(gatt.DeviceManager):
         GObject.timeout_add(timeout, self.stop)
 
     def device_discovered(self, device):
-        if device.alias() in ("InfiniTime", "Pinetime-JF", "PineTime"):
-            self.scan_result = True
-            self.aliases[device.mac_address] = device.alias()
-            self.device_set.add(device.mac_address)
+        for prefix in ["InfiniTime", "Pinetime-JF", "PineTime"]:
+            if device.alias().startswith(prefix):
+                self.scan_result = True
+                self.aliases[device.mac_address] = device.alias()
+                self.device_set.add(device.mac_address)
 
     def scan_for_infinitime(self):
         self.start_discovery()


### PR DESCRIPTION
Currently PineTime watches are detected by the device alias so if the
user changes the alias they are no longer listed in Siglo. This is
pretty hard to fix because there's no good way to actually detect it any
other way. This fix lets people at least add an suffix to the alias to
differentiate devices.

Fixes #54 