### PR TITLE
add alpine build instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Gtk >= 3.30
 ## Download and Install
 [Download the latest stable version from Flathub](https://flathub.org/apps/details/com.github.alexr4535.siglo) (Warning: SMS Notifications currently broken in flatpak https://github.com/alexr4535/siglo/issues/80).
 
+### Alpine
+Works for Alpine and other Alpine-based distribution, such as [postmarketOS](https://postmarketos.org/).
+
+```sh
+sudo apk add gettext glib-dev meson py3-dbus py3-pip python3 
+pip3 install gatt pyxdg
+```
+
 ### Arch Linux
 
 ```sh


### PR DESCRIPTION
Adds an Alpine section to the README for users that want to build and install it on Alpine.
In my case, I was just building it directly on my PinePhone on postmarketOS/phosh.

Following this, I was able to pair my PineTime, update the firmware, etc. 🎉 

It's worth clarifying that the instructions work on postmarketOS explicitly, for those that don't know it's Alpine-based. This keeps things more beginner-friendly to help with adoption.