### PR TITLE
docs: add missing dependency to build on alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Gtk >= 3.30
 Works for Alpine and other Alpine-based distribution, such as [postmarketOS](https://postmarketos.org/).
 
 ```sh
-sudo apk add gettext glib-dev meson py3-dbus py3-pip python3 
-pip3 install gatt 
+sudo apk add desktop-file-utils gettext glib-dev meson py3-dbus py3-pip python3 
+pip3 install gatt
 ```
 
 ### Arch Linux

--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ GTK app to sync InfiniTime watch with PinePhone
 'siglo' means century in Spanish
 
 ## Requirements
+
 Gtk >= 3.30
 
 ## Download and Install
+
 [Download the latest stable version from Flathub](https://flathub.org/apps/details/com.github.theironrobin.siglo) (Warning: SMS Notifications currently broken in flatpak https://github.com/theironrobin/siglo/issues/80).
 
 ### Alpine
+
 Works for Alpine and other Alpine-based distribution, such as [postmarketOS](https://postmarketos.org/).
 
 ```sh
@@ -52,7 +55,7 @@ sudo ninja install
 
 ### Mocked Testing with Docker
 
-While you won't get bluetooth connectivity, you can get some high-level vetting in a container, which
+While you won't get Bluetooth connectivity, you can get some high-level vetting in a container, which
 will open the way forward to better CI testing on GitHub.
 
 The [`Dockerfile`](Dockerfile) contains all required dependencies, in addition to
@@ -99,7 +102,7 @@ Transfer the `siglo.flatpak` file on the PinePhone and install it with the follo
 sudo flatpak install ./siglo.flatpak
 ```
 
-##
+---
 
 If this project helped you, you can buy me a cup of coffee :)
 <br/><br/>


### PR DESCRIPTION
Ran into the following while trying to build Siglo:

```
Program desktop-file-validate found: NO
```

```
--- stderr ---
Traceback (most recent call last):
  File "/home/user/Documents/repos/theironrobin/siglo/build-aux/meson/postinstall.py", line 16, in <module>
    call(['update-desktop-database', '-q', path.join(datadir, 'applications')])
  File "/usr/lib/python3.10/subprocess.py", line 345, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/lib/python3.10/subprocess.py", line 966, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1842, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'update-desktop-database'
```

On Alpine the package is just called `desktop-file-utils` too. 👍🏾 
Just adds it to the list of dependencies for building on Alpine.

---

While I was at it, I also made some subtle changes to the README.
* Made line breaks under headings more consistent.
* Replaced the empty heading at the bottom with an an actual horizontal line rather than kind of simulating one with the underline that headers get.
* Fixed a typo. (Bluetooth starts with an uppercase characters!)