### PR TITLE
gitignore: Ignore .flatpak folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ dmypy.json
 .pyre/
 
 # Flatpak
+.flatpak/
 .flatpak-builder/
 build-dir/
 repo/


### PR DESCRIPTION
Ignores the `.flatpak` folder that is created by the Flatpak VS Codium extension.