### PR TITLE
Update Flatpak manifest

### DIFF
--- a/com.github.theironrobin.siglo.json
+++ b/com.github.theironrobin.siglo.json
@@ -1,6 +1,6 @@
 {
-    "app-id" : "com.github.theironrobin.siglo",
-    "runtime" : "org.gnome.Platform",   
+    "id" : "com.github.theironrobin.siglo",
+    "runtime" : "org.gnome.Platform",
     "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "siglo",

--- a/com.github.theironrobin.siglo.json
+++ b/com.github.theironrobin.siglo.json
@@ -10,7 +10,8 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--system-talk-name=org.bluez",
-        "--socket=wayland"
+        "--socket=wayland",
+        "--device=dri"
     ],
     "cleanup" : [
         "/include",

--- a/com.github.theironrobin.siglo.json
+++ b/com.github.theironrobin.siglo.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.theironrobin.siglo",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime" : "org.gnome.Platform",   
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "siglo",
     "finish-args" : [


### PR DESCRIPTION
Updates the Flatpak manifest to use version 44 of the GNOME SDK, adds dri device permission for accelerated rendering, and changes the deprecated *app-id* property key.

Closes #121 