### PR TITLE
docs: use py3-gatt on Alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Gtk >= 3.30
 Works for Alpine and other Alpine-based distribution, such as [postmarketOS](https://postmarketos.org/).
 
 ```sh
-sudo apk add desktop-file-utils gettext glib-dev meson py3-dbus py3-pip python3 
-pip3 install gatt
+sudo apk add desktop-file-utils gettext glib-dev meson py3-dbus py3-pip py3-gatt
 ```
 
 ### Arch Linux


### PR DESCRIPTION
The gatt package is already packaged on the Alpine repositories, so use that for building instead.

The previous instructions did not work anyway; pip will refuse to operate on the system-wide installation by default.

The `python3` package is a transitive dependency, so does not need to be specified explicitly.